### PR TITLE
Allow files uploaded to the task directly to be stacked

### DIFF
--- a/REST_API.md
+++ b/REST_API.md
@@ -231,9 +231,10 @@ remaining steps then process. Unlike a normal task, a stacking task is created
 
 **Requirements:**
 - `stack_filenames` — a list of **absolute paths** to the input images. Every
-  path must reside under the server's `DATA_PATH` (paths outside it are rejected
-  for security). These are server-side paths, so the files must already exist in
-  the data directory (e.g. previously uploaded or otherwise placed there).
+  path must reside under the server's `DATA_PATH` or the task's path 
+  `TASKS_PATH/{task_id}` (paths outside these are rejected for security). 
+  These are server-side paths, so the files must already exist in the data 
+  directory (e.g. previously uploaded or otherwise placed there).
 - At least two input images.
 - Include `stack` as the first entry in `steps` (before `inspect`).
 
@@ -604,7 +605,7 @@ The task `config` object accepts these parameters:
 ### Stacking
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `stack_filenames` | list | - | Absolute paths of input images to coadd (must be under `DATA_PATH`, at least two) |
+| `stack_filenames` | list | - | Absolute paths of input images to coadd (must be under `DATA_PATH` or `TASKS_PATH/{task_id}`, at least two files) |
 | `stack_method` | string | "sum" | Coaddition method: `sum`, `clipped_mean`, or `median` |
 | `stack_subtract_bg` | bool | true | Subtract background from each input before stacking |
 | `stack_mask_cosmics` | bool | false | Mask cosmic rays in each input before stacking |

--- a/stdweb/celery_tasks.py
+++ b/stdweb/celery_tasks.py
@@ -350,7 +350,7 @@ def task_stacking(self, id, finalize=True):
 
         # Start processing
         try:
-            processing.stack_images(config['stack_filenames'], os.path.join(basepath, 'image.fits'), config, verbose=log)
+            processing.stack_images(config['stack_filenames'], basepath, os.path.join(basepath, 'image.fits'), config, verbose=log)
             task.state = 'stacking_done'
         except:
             import traceback

--- a/stdweb/processing/stacking.py
+++ b/stdweb/processing/stacking.py
@@ -22,8 +22,8 @@ from .constants import *
 from .utils import *
 
 
-def validate_under_data_path(filenames):
-    """Ensure every stacking input path stays under DATA_PATH.
+def validate_under_data_or_basepath(filenames, basepath):
+    """Ensure every stacking input path stays under DATA_PATH or task's basepath.
 
     Guards against path traversal in user-supplied stack_filenames (which may
     also arrive via the API, bypassing the upload view sanitization).
@@ -33,19 +33,20 @@ def validate_under_data_path(filenames):
     they are in the file browser.
     """
     datapath = os.path.abspath(settings.DATA_PATH)
+    basepath = os.path.abspath(basepath)
 
     for filename in filenames:
         path = os.path.abspath(filename)
-        if path != datapath and not path.startswith(datapath + os.sep):
-            raise RuntimeError(f"Stacking input path is outside of DATA_PATH: {filename}")
+        if path != datapath and path != basepath and not path.startswith(datapath + os.sep) and not path.startswith(basepath + os.sep):
+            raise RuntimeError(f"Stacking input path is outside of DATA_PATH or task path: {filename}")
 
 
-def stack_images(filenames, outname, config, verbose=True):
+def stack_images(filenames, basepath, outname, config, verbose=True):
     # Simple wrapper around print for logging in verbose mode only
     log = (verbose if callable(verbose) else print) if verbose else lambda *args,**kwargs: None
 
     # Safeguard: refuse to read inputs from outside the allowed data directory
-    validate_under_data_path(filenames)
+    validate_under_data_or_basepath(filenames, basepath)
 
     if len(filenames) < 2:
         raise RuntimeError(f"Stacking requires at least 2 images, got {len(filenames)}")

--- a/stdweb/processing/tests/test_stacking.py
+++ b/stdweb/processing/tests/test_stacking.py
@@ -82,7 +82,7 @@ def test_stack_without_wcs_uses_astroalign(tmp_path, settings):
     assert not WCS(fits.getheader(f0)).is_celestial
 
     out = str(tmp_path / 'stack.fits')
-    stack_images([f0, f1], out,
+    stack_images([f0, f1], tmp_path, out,
                  {'stack_method': 'sum', 'stack_subtract_bg': False},
                  verbose=False)
 
@@ -123,7 +123,7 @@ def test_stack_with_broken_wcs_falls_back_to_astroalign(tmp_path, settings):
     assert WCS(fits.getheader(f0)).is_celestial
 
     out = str(tmp_path / 'stack.fits')
-    stack_images([f0, f1], out,
+    stack_images([f0, f1], tmp_path, out,
                  {'stack_method': 'sum', 'stack_subtract_bg': False},
                  verbose=False)
 
@@ -157,7 +157,7 @@ def test_stack_task229_nowcs_fixtures(tmp_path):
     assert not WCS(fits.getheader(files[0])).is_celestial
 
     out = str(tmp_path / 'image.fits')
-    stack_images(files, out, {'stack_method': 'median'}, verbose=False)
+    stack_images(files, tmp_path, out, {'stack_method': 'median'}, verbose=False)
 
     assert os.path.exists(out)
     coadd = fits.getdata(out)


### PR DESCRIPTION
- Added `TASKS_PATH/{task_id}` to allowed directories
- Updated REST_API.md

Considerations:
Currently the stacking workflow is very different than the one image workflow. Maybe normal tasks should be able to use a path from `DATA_PATH` instead of `image.fits` too. Another option is to allow stacking one image, which will just copy it over or symlink to image.fits.